### PR TITLE
Use reified parameter for `executeCatching`; allow exception handlers to be sync or async

### DIFF
--- a/src/main/kotlin/net/axay/kspigot/runnables/ChainableRunnables.kt
+++ b/src/main/kotlin/net/axay/kspigot/runnables/ChainableRunnables.kt
@@ -12,6 +12,9 @@ abstract class ChainedRunnablePart<T, R>(
 
     protected abstract fun invoke(data: T): R
 
+    /**
+     * Begins execution of this chained runnable.
+     */
     abstract fun execute()
 
     /**
@@ -71,6 +74,7 @@ abstract class ChainedRunnablePart<T, R>(
             next?.startCatching(result, exceptionClass, exceptionSync, exceptionHandler)
         }
     }
+
 }
 
 class ChainedRunnablePartFirst<R>(
@@ -85,8 +89,7 @@ class ChainedRunnablePartFirst<R>(
         exceptionClass: KClass<E>,
         exceptionSync: Boolean,
         exceptionHandler: ((E) -> Unit)?
-    ) =
-        startCatching(Unit, exceptionClass, exceptionSync, exceptionHandler)
+    ) = startCatching(Unit, exceptionClass, exceptionSync, exceptionHandler)
 
     override fun invoke(data: Unit) = runnable.invoke()
 
@@ -105,8 +108,7 @@ class ChainedRunnablePartThen<T, R>(
         exceptionClass: KClass<E>,
         exceptionSync: Boolean,
         exceptionHandler: ((E) -> Unit)?
-    ) =
-        previous.executeCatchingImpl(exceptionClass, exceptionSync, exceptionHandler)
+    ) = previous.executeCatchingImpl(exceptionClass, exceptionSync, exceptionHandler)
 
     override fun invoke(data: T) = runnable.invoke(data)
 

--- a/src/main/kotlin/net/axay/kspigot/runnables/ChainableRunnables.kt
+++ b/src/main/kotlin/net/axay/kspigot/runnables/ChainableRunnables.kt
@@ -40,7 +40,7 @@ abstract class ChainedRunnablePart<T, R>(
     )
 
     protected fun start(data: T) {
-        runTask(sync) {
+        bukkitRun(sync) {
             val result = invoke(data)
             next?.start(result)
         }
@@ -52,7 +52,7 @@ abstract class ChainedRunnablePart<T, R>(
         exceptionSync: Boolean,
         exceptionHandler: ((E) -> Unit)?,
     ) {
-        runTask(sync) {
+        bukkitRun(sync) {
             val result = try {
                 invoke(data)
             } catch (e: Exception) {
@@ -61,11 +61,11 @@ abstract class ChainedRunnablePart<T, R>(
                     if (sync == exceptionSync) {
                         exceptionHandler?.invoke(e as E)
                     } else if (exceptionHandler != null) {
-                        runTask(exceptionSync) {
+                        bukkitRun(exceptionSync) {
                             exceptionHandler.invoke(e as E)
                         }
                     }
-                    return@runTask
+                    return@bukkitRun
                 } else throw e
             }
             next?.startCatching(result, exceptionClass, exceptionSync, exceptionHandler)

--- a/src/main/kotlin/net/axay/kspigot/runnables/KSpigotRunnables.kt
+++ b/src/main/kotlin/net/axay/kspigot/runnables/KSpigotRunnables.kt
@@ -104,7 +104,11 @@ fun task(
 
 }
 
-fun runTask(sync: Boolean, runnable: () -> Unit) {
+/**
+ * Executes the given [runnable] either
+ * sync or async (specified by the [sync] parameter).
+ */
+fun bukkitRun(sync: Boolean, runnable: () -> Unit) {
     if (sync) {
         sync(runnable)
     } else {

--- a/src/main/kotlin/net/axay/kspigot/runnables/KSpigotRunnables.kt
+++ b/src/main/kotlin/net/axay/kspigot/runnables/KSpigotRunnables.kt
@@ -104,6 +104,14 @@ fun task(
 
 }
 
+fun runTask(sync: Boolean, runnable: () -> Unit) {
+    if (sync) {
+        sync(runnable)
+    } else {
+        async(runnable)
+    }
+}
+
 /**
  * Starts a synchronous task.
  */


### PR DESCRIPTION
The previous default parameter for `exceptionClass` would throw when any other class than `Exception` was passed as a type parameter without explicitly passing the class. The solution using reified type parameters avoids this problem and allows for easy usage of the function.

Exception handlers now also specify whether they are to be executed sync or async, defaulting to sync for safe usage of the Spigot API.

The `runTask` function is used to execute a runnable either sync or async, I believe a better name would be simply `task`, but this collides with the exisiting `task` function. Maybe renaming the existing one to `repeatingTask` or similar would be beneficial, but introduces another breaking change to the API.